### PR TITLE
Update BCH Explorer URL to new domain

### DIFF
--- a/src/pages/build.astro
+++ b/src/pages/build.astro
@@ -499,7 +499,7 @@ const metadata = {
         title: 'BCH Explorer',
         description: 'Includes helpful graphs.',
         icon: '',
-        url: 'https://explorer.melroy.org/',
+        url: 'https://bchexplorer.cash/',
       },
       {
         title: 'Bitcoin Verde Explorer',


### PR DESCRIPTION
I registered a new domain now: https://bchexplorer.cash.. Better right?

Also I'm working on a v3 (currently still WIP, but coming soon): https://gitlab.melroy.org/bitcoincash/bitcoin-cash-explorer